### PR TITLE
Fix mutable appends on URL string literals for Ruby 3.4

### DIFF
--- a/lib/add_to_calendar.rb
+++ b/lib/add_to_calendar.rb
@@ -30,7 +30,7 @@ module AddToCalendar
   
     def google_url
       # Eg. https://www.google.com/calendar/render?action=TEMPLATE&text=Holly%27s%208th%20Birthday!&dates=20200615T180000/20200615T190000&ctz=Europe/London&details=Join%20us%20to%20celebrate%20with%20lots%20of%20games%20and%20cake!&location=Apartments,%20London&sprop=&sprop=name:
-      calendar_url = "https://www.google.com/calendar/render?action=TEMPLATE"
+      calendar_url = "https://www.google.com/calendar/render?action=TEMPLATE".dup
       params = {}
       params[:text] = url_encode(title)
       params[:dates] = google_dates(start_datetime, end_datetime, all_day)
@@ -54,7 +54,7 @@ module AddToCalendar
 
     def yahoo_url
       # Eg. https://calendar.yahoo.com/?v=60&title=Holly%27s%208th%20Birthday!&st=20200615T170000Z&dur=0100&desc=Join%20us%20to%20celebrate%20with%20lots%20of%20games%20and%20cake!&in_loc=7%20Apartments,%20London
-      calendar_url = "https://calendar.yahoo.com/?v=60"
+      calendar_url = "https://calendar.yahoo.com/?v=60".dup
       params = {}
       params[:title] = url_encode(title)
       if all_day
@@ -93,7 +93,7 @@ module AddToCalendar
     end
 
     def hey_url
-      calendar_url = "https://app.hey.com/calendar/ical_events/new?ical_source=BEGIN%3AVCALENDAR%0AVERSION%3A2.0%0APRODID%3A-//AddToCalendar//RubyGem//EN%0ABEGIN%3AVEVENT"
+      calendar_url = "https://app.hey.com/calendar/ical_events/new?ical_source=BEGIN%3AVCALENDAR%0AVERSION%3A2.0%0APRODID%3A-//AddToCalendar//RubyGem//EN%0ABEGIN%3AVEVENT".dup
       
       params = {}
       params[:SUMMARY] = url_encode(title)
@@ -158,7 +158,7 @@ module AddToCalendar
     def ical_url
       # Downloads a *.ics file provided as a data-uri
       # Eg. "data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0ABEGIN:VEVENT%0ADTSTART:20200512T123000Z%0ADTEND:20200512T160000Z%0ASUMMARY:Holly%27s%208th%20Birthday%21%0AURL:https%3A%2F%2Fwww.example.com%2Fevent-details%0ADESCRIPTION:Come%20join%20us%20for%20lots%20of%20fun%20%26%20cake%21\\n\\nhttps%3A%2F%2Fwww.example.com%2Fevent-details%0ALOCATION:Flat%204%5C%2C%20The%20Edge%5C%2C%2038%20Smith-Dorrien%20St%5C%2C%20London%5C%2C%20N1%207GU%0AUID:-https%3A%2F%2Fwww.example.com%2Fevent-details%0AEND:VEVENT%0AEND:VCALENDAR"
-      calendar_url = "data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0APRODID:-//AddToCalendar//RubyGem//EN%0ABEGIN:VEVENT"
+      calendar_url = "data:text/calendar;charset=utf8,BEGIN:VCALENDAR%0AVERSION:2.0%0APRODID:-//AddToCalendar//RubyGem//EN%0ABEGIN:VEVENT".dup
 
       params = {}
       params[:DTSTAMP] = Time.now.strftime("%Y%m%dT%H%M%SZ")
@@ -252,9 +252,9 @@ module AddToCalendar
       def microsoft(service)
         # Eg. 
         if service == "outlook.com"
-          calendar_url = "https://outlook.live.com/calendar/0/action/compose?rru=addevent"
+          calendar_url = "https://outlook.live.com/calendar/0/action/compose?rru=addevent".dup
         elsif service == "office365"
-          calendar_url = "https://outlook.office.com/calendar/0/action/compose?rru=addevent"
+          calendar_url = "https://outlook.office.com/calendar/0/action/compose?rru=addevent".dup
         else
           raise MicrosoftServiceError, ":service must be 'outlook.com' or 'office365'. '#{service}' given"
         end


### PR DESCRIPTION
Duplicate base calendar URL strings with .dup before using << so Ruby does not warn about mutating string literals (“literal string will be frozen in the future”) on google_url and microsoft (Outlook / Office 365).